### PR TITLE
feat(nix): add flake file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762596750,
+        "narHash": "sha256-rXXuz51Bq7DHBlfIjN7jO8Bu3du5TV+3DSADBX7/9YQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6a8526db03f735b89dd5ff348f53f752e7ddc8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Standalone Neovim config";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, ... }: {
+    homeModules.nvim-config = { pkgs, ... }: {
+      home.packages = with pkgs; [
+        gnumake
+        ripgrep
+        neovide
+      ];
+
+      xdg.configFile."nvim" = {
+        source = "${self}";
+        recursive = true;
+      };
+
+      programs.neovim = {
+        enable = true;
+        defaultEditor = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add a flake.lock file to lock Nix dependency versions
Create a flake.nix file to define the Neovim configuration module
Set Neovim as the default editor
Add commonly used tools (e.g., gnumake, ripgrep, neovide)
Recursively symlink the Neovim config directory to the project root